### PR TITLE
[cyrus-sasl]: Add inspec tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,18 @@
-# base-plan-skeleton
-Template for all new Chef Base Plans to simplify creation of repositories.
+# cyrus-sasl
+
+Cyrus Simple Authentication Service Layer (SASL) library
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+Typically this is a runtime dependency that can be added to your
+plan.sh:
+
+    pkg_deps=(core/cyrus-sasl)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://dev.azure.com/chefcorp-partnerengineering/Chef%20Base%20Plans/_apis/build/status/chef-base-plans.cyrus-sasl?branchName=master)](https://dev.azure.com/chefcorp-partnerengineering/Chef%20Base%20Plans/_build/latest?definitionId=69&branchName=master)
+
 # cyrus-sasl
 
 Cyrus Simple Authentication Service Layer (SASL) library

--- a/attributes.yml
+++ b/attributes.yml
@@ -1,1 +1,1 @@
-command_relative_path: '/sbin/saslauthd'
+command_relative_path: 'sbin/saslauthd'

--- a/attributes.yml
+++ b/attributes.yml
@@ -1,0 +1,1 @@
+command_relative_path: '/sbin/saslauthd'

--- a/controls/cyrus-sasl_exists.rb
+++ b/controls/cyrus-sasl_exists.rb
@@ -7,7 +7,8 @@ control 'core-plans-cyrus-sasl-exists' do
   impact 1.0
   title 'Ensure cyrus-sasl exists'
   desc '
-  '
+  Verify cyrus-sasl by ensuring /sbin/saslauthd exists'
+  
   plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
   describe plan_installation_directory do
     its('exit_status') { should eq 0 }

--- a/controls/cyrus-sasl_exists.rb
+++ b/controls/cyrus-sasl_exists.rb
@@ -2,12 +2,12 @@ title 'Tests to confirm cyrus-sasl exists'
 
 plan_origin = ENV['HAB_ORIGIN']
 plan_name = input('plan_name', value: 'cyrus-sasl')
- 
+
 control 'core-plans-cyrus-sasl-exists' do
   impact 1.0
   title 'Ensure cyrus-sasl exists'
   desc '
-  Verify cyrus-sasl by ensuring /sbin/saslauthd exists'
+  Verify cyrus-sasl by ensuring sbin/saslauthd exists'
   
   plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
   describe plan_installation_directory do
@@ -15,8 +15,8 @@ control 'core-plans-cyrus-sasl-exists' do
     its('stdout') { should_not be_empty }
   end
 
-  command_relative_path = input('command_relative_path', value: '/sbin/saslauthd')
-  command_full_path = plan_installation_directory.stdout.strip + "#{command_relative_path}"
+  command_relative_path = input('command_relative_path', value: 'sbin/saslauthd')
+  command_full_path = File.join(plan_installation_directory.stdout.strip, "#{command_relative_path}")
   describe file(command_full_path) do
     it { should exist }
   end

--- a/controls/cyrus-sasl_exists.rb
+++ b/controls/cyrus-sasl_exists.rb
@@ -13,6 +13,7 @@ control 'core-plans-cyrus-sasl-exists' do
   describe plan_installation_directory do
     its('exit_status') { should eq 0 }
     its('stdout') { should_not be_empty }
+    its('stderr') { should be_empty }
   end
 
   command_relative_path = input('command_relative_path', value: 'sbin/saslauthd')

--- a/controls/cyrus-sasl_exists.rb
+++ b/controls/cyrus-sasl_exists.rb
@@ -1,0 +1,22 @@
+title 'Tests to confirm cyrus-sasl exists'
+
+plan_origin = ENV['HAB_ORIGIN']
+plan_name = input('plan_name', value: 'cyrus-sasl')
+ 
+control 'core-plans-cyrus-sasl-exists' do
+  impact 1.0
+  title 'Ensure cyrus-sasl exists'
+  desc '
+  '
+  plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
+  describe plan_installation_directory do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+  end
+
+  command_relative_path = input('command_relative_path', value: '/sbin/saslauthd')
+  command_full_path = plan_installation_directory.stdout.strip + "#{command_relative_path}"
+  describe file(command_full_path) do
+    it { should exist }
+  end
+end

--- a/controls/cyrus-sasl_works.rb
+++ b/controls/cyrus-sasl_works.rb
@@ -7,7 +7,10 @@ control 'core-plans-cyrus-sasl-works' do
   impact 1.0
   title 'Ensure cyrus-sasl works as expected'
   desc '
+  Verify cyrus-sasl by ensuring (1) its installation directory exists and (2) that
+  it returns the expected version
   '
+  
   plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
   describe plan_installation_directory do
     its('exit_status') { should eq 0 }

--- a/controls/cyrus-sasl_works.rb
+++ b/controls/cyrus-sasl_works.rb
@@ -1,0 +1,25 @@
+title 'Tests to confirm cyrus-sasl works as expected'
+
+plan_origin = ENV['HAB_ORIGIN']
+plan_name = input('plan_name', value: 'cyrus-sasl')
+
+control 'core-plans-cyrus-sasl-works' do
+  impact 1.0
+  title 'Ensure cyrus-sasl works as expected'
+  desc '
+  '
+  plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
+  describe plan_installation_directory do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+  end
+  
+  plan_pkg_ident = ((plan_installation_directory.stdout.strip).match /(?<=pkgs\/)(.*)/)[1]
+  plan_pkg_version = (plan_pkg_ident.match /^#{plan_origin}\/#{plan_name}\/(?<version>.*)\//)[:version]
+  describe command("DEBUG=true; hab pkg exec #{plan_pkg_ident} saslauthd --version") do
+    its('exit_status') { should eq 0 }
+    its('stderr') { should_not be_empty }
+    its('stderr') { should match /saslauthd #{plan_pkg_version}/ }
+    its('stdout') { should be_empty }
+  end
+end

--- a/controls/cyrus-sasl_works.rb
+++ b/controls/cyrus-sasl_works.rb
@@ -7,8 +7,9 @@ control 'core-plans-cyrus-sasl-works' do
   impact 1.0
   title 'Ensure cyrus-sasl works as expected'
   desc '
-  Verify cyrus-sasl by ensuring (1) its installation directory exists and (2) that
-  it returns the expected version
+  Verify cyrus-sasl by ensuring 
+  (1) its installation directory exists and 
+  (2) that it returns the expected version.
   '
   
   plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
@@ -17,9 +18,10 @@ control 'core-plans-cyrus-sasl-works' do
     its('stdout') { should_not be_empty }
   end
   
-  plan_pkg_ident = ((plan_installation_directory.stdout.strip).match /(?<=pkgs\/)(.*)/)[1]
-  plan_pkg_version = (plan_pkg_ident.match /^#{plan_origin}\/#{plan_name}\/(?<version>.*)\//)[:version]
-  describe command("DEBUG=true; hab pkg exec #{plan_pkg_ident} saslauthd --version") do
+  command_relative_path = input('command_relative_path', value: 'sbin/saslauthd')
+  command_full_path = File.join(plan_installation_directory.stdout.strip, "#{command_relative_path}")
+  plan_pkg_version = plan_installation_directory.stdout.split("/")[5]
+  describe command("#{command_full_path} --version") do
     its('exit_status') { should eq 0 }
     its('stderr') { should_not be_empty }
     its('stderr') { should match /saslauthd #{plan_pkg_version}/ }

--- a/controls/cyrus-sasl_works.rb
+++ b/controls/cyrus-sasl_works.rb
@@ -16,6 +16,7 @@ control 'core-plans-cyrus-sasl-works' do
   describe plan_installation_directory do
     its('exit_status') { should eq 0 }
     its('stdout') { should_not be_empty }
+    its('stderr') { should be_empty }
   end
   
   command_relative_path = input('command_relative_path', value: 'sbin/saslauthd')

--- a/inspec.yml
+++ b/inspec.yml
@@ -1,9 +1,9 @@
-name: {{plan_name}}
-title: Habitat Core Plan {{plan_name}}
-maintainer: humans@habitat.sh
-summary: InSpec controls for testing Habitat Core Plan {{plan_name}}
-copyright: humans@habitat.sh
-copyright_email: humans@habitat.sh
+name: cyrus-sasl
+title: Habitat Core Plan cyrus-sasl
+maintainer: "The Habitat Maintainers <humans@habitat.sh>"
+summary: InSpec controls for testing Habitat Core Plan cyrus-sasl
+copyright: 2019, Chef Software, Inc.
+copyright_email: legal@chef.io
 version: 0.1.0
 license: Apache-2.0
 inspec_version: '>= 3.0.25'

--- a/plan.sh
+++ b/plan.sh
@@ -1,0 +1,27 @@
+pkg_origin=core
+pkg_name=cyrus-sasl
+pkg_version=2.1.27
+pkg_description="Cyrus Simple Authentication Service Layer (SASL) library"
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_license=("custom") # 4-Clause-BSD-like, see http://www.cyrusimap.org/mediawiki/index.php/Downloads#Licensing
+pkg_upstream_url=http://www.cyrusimap.org/
+pkg_source=https://ftp.osuosl.org/pub/blfs/conglomeration/cyrus-sasl/${pkg_name}-${pkg_version}.tar.gz
+pkg_shasum=26866b1549b00ffd020f188a43c258017fa1c382b3ddadd8201536f72efb05d5
+pkg_deps=(core/glibc core/openssl)
+pkg_build_deps=(core/gcc core/make)
+pkg_bin_dirs=(sbin)
+pkg_include_dirs=(include)
+pkg_lib_dirs=(lib)
+
+do_build() {
+  ./configure --prefix="${pkg_prefix}" \
+              --with-plugindir="${pkg_prefix}/lib/sasl2" \
+              --enable-auth-sasldb \
+              --with-saslauthd="${pkg_svc_var_path}/run/saslauthd"
+  make
+}
+
+do_install() {
+  make install
+  install -m644 COPYING "${pkg_prefix}/share/"
+}

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -1,0 +1,11 @@
+TEST_PKG_VERSION="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
+
+@test "Version matches" {
+  result="$(hab pkg exec "${TEST_PKG_IDENT}" saslauthd -v 2>&1 | head -n1 | awk '{print $2}')"
+  [ "$result" = "${TEST_PKG_VERSION}" ]
+}
+
+@test "saslauthd command" {
+  run hab pkg exec "${TEST_PKG_IDENT}" saslauthd -h 2>&1
+  [ $status -eq 0 ]
+}

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+#/ Usage: test.sh <pkg_ident>
+#/
+#/ Example: test.sh core/tlog/6/20181108151533
+#/
+
+set -euo pipefail
+
+if [[ -z "${1:-}" ]]; then
+  grep '^#/' < "${0}" | cut -c4-
+	exit 1
+fi
+
+TEST_PKG_IDENT="${1}"
+export TEST_PKG_IDENT
+hab pkg install core/bats --binlink
+hab pkg install "${TEST_PKG_IDENT}"
+
+bats "$(dirname "${0}")/test.bats"


### PR DESCRIPTION
### Outstanding tasks:
- [x] remove DEBUG
- [x] use full path to binary instead of hab pkg exec
- [x] parsing the pkg_version from the installation path.

```rspec
hab pkg exec chef/inspec inspec exec /src/. --chef-license=accept -t docker://8b505d53b900a79ac787469497c2ec7c3408edd380df4d7a165cd2d36a0ed208 --input-file /src/attributes.yml

Profile: Habitat Core Plan cyrus-sasl (cyrus-sasl)
Version: 0.1.0
Target:  docker://8b505d53b900a79ac787469497c2ec7c3408edd380df4d7a165cd2d36a0ed208

  ✔  core-plans-cyrus-sasl-works: Ensure cyrus-sasl works as expected
     ✔  Command: `hab pkg path core/cyrus-sasl` exit_status is expected to eq 0
     ✔  Command: `hab pkg path core/cyrus-sasl` stdout is expected not to be empty
     ✔  Command: `DEBUG=true; hab pkg exec core/cyrus-sasl/2.1.27/20200603134528 saslauthd -v` exit_status is expected to eq 0
     ✔  Command: `DEBUG=true; hab pkg exec core/cyrus-sasl/2.1.27/20200603134528 saslauthd -v` stderr is expected not to be empty
     ✔  Command: `DEBUG=true; hab pkg exec core/cyrus-sasl/2.1.27/20200603134528 saslauthd -v` stderr is expected to match /saslauthd 2.1.27/
     ✔  Command: `DEBUG=true; hab pkg exec core/cyrus-sasl/2.1.27/20200603134528 saslauthd -v` stdout is expected to be empty
  ✔  core-plans-cyrus-sasl-exists: Ensure cyrus-sasl exists
     ✔  File /hab/pkgs/core/cyrus-sasl/2.1.27/20200603134528/sbin/saslauthd is expected to exist


Profile Summary: 2 successful controls, 0 control failures, 0 controls skipped
Test Summary: 7 successful, 0 failures, 0 skipped
+ set +x
[16][default:/src:0]# 
```